### PR TITLE
プロンプトコンテンツのマッピング機能を追加

### DIFF
--- a/VideoIndexerAccess/Repositories/DataModel/PromptContentRequestModel.cs
+++ b/VideoIndexerAccess/Repositories/DataModel/PromptContentRequestModel.cs
@@ -1,0 +1,9 @@
+﻿namespace VideoIndexerAccess.Repositories.DataModel
+{
+    public class PromptContentRequestModel
+    {
+        public required string VideoId { get; set; }
+        public string? ModelName { get; set; }
+        public string? PromptStyle { get; set; }
+    }
+}

--- a/VideoIndexerAccess/Repositories/DataModel/PromptCreateResponseModel.cs
+++ b/VideoIndexerAccess/Repositories/DataModel/PromptCreateResponseModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VideoIndexerAccess.Repositories.DataModel
+{
+    public class PromptCreateResponseModel
+    {
+        public string? ErrorType { get; set; }
+        public string? Message { get; set; }
+    }
+}

--- a/VideoIndexerAccess/Repositories/DataModelMapper/IPromptCreateResponseMapper.cs
+++ b/VideoIndexerAccess/Repositories/DataModelMapper/IPromptCreateResponseMapper.cs
@@ -1,0 +1,10 @@
+﻿using VideoIndexerAccess.Repositories.DataModel;
+using VideoIndexerAccessCore.VideoIndexerClient.ApiModel;
+
+namespace VideoIndexerAccess.Repositories.DataModelMapper;
+
+public interface IPromptCreateResponseMapper
+{
+    PromptCreateResponseModel MapFrom(ApiPromptCreateResponseModel model);
+    ApiPromptCreateResponseModel MapTo(PromptCreateResponseModel model);
+}

--- a/VideoIndexerAccess/Repositories/DataModelMapper/PromptCreateResponseMapper.cs
+++ b/VideoIndexerAccess/Repositories/DataModelMapper/PromptCreateResponseMapper.cs
@@ -1,0 +1,26 @@
+﻿using VideoIndexerAccess.Repositories.DataModel;
+using VideoIndexerAccessCore.VideoIndexerClient.ApiModel;
+
+namespace VideoIndexerAccess.Repositories.DataModelMapper
+{
+    public class PromptCreateResponseMapper : IPromptCreateResponseMapper
+    {
+        public PromptCreateResponseModel MapFrom(ApiPromptCreateResponseModel model)
+        {
+            return new PromptCreateResponseModel()
+            {
+                ErrorType = model.errorType,
+                Message = model.message,
+            };
+        }
+
+        public ApiPromptCreateResponseModel MapTo(PromptCreateResponseModel model)
+        {
+            return new ApiPromptCreateResponseModel()
+            {
+                errorType = model.ErrorType,
+                message = model.Message,
+            };
+        }
+    }
+}

--- a/VideoIndexerAccess/Repositories/VideoItemRepository/PromptContentRepository.cs
+++ b/VideoIndexerAccess/Repositories/VideoItemRepository/PromptContentRepository.cs
@@ -1,0 +1,113 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VideoIndexerAccess.Repositories.AuthorizAccess;
+using VideoIndexerAccess.Repositories.DataModel;
+using VideoIndexerAccess.Repositories.DataModelMapper;
+using VideoIndexerAccessCore.VideoIndexerClient.ApiAccess;
+using VideoIndexerAccessCore.VideoIndexerClient.ApiModel;
+using VideoIndexerAccessCore.VideoIndexerClient.Configuration;
+using VideoIndexerAccessCore.VideoIndexerClient.HttpAccess;
+
+namespace VideoIndexerAccess.Repositories.VideoItemRepository
+{
+    public class PromptContentRepository
+    {
+        // ロガーインスタンス
+        private readonly ILogger<ProjectsRepository> _logger;
+
+        // アクセストークン取得用インターフェース
+        private readonly IAuthenticationTokenizer _authenticationTokenizer;
+
+        // アカウント情報取得用インターフェース
+        private readonly IAccounApitAccess _accountAccess;
+
+        // アカウント検証用リポジトリ
+        private readonly IAccountRepository _accountRepository;
+
+        // APIリソース設定
+        private readonly IApiResourceConfigurations _apiResourceConfigurations;
+
+        // API設定
+        private readonly IPromptContentApiAccess _promptContentApiAccess;
+
+        // プロンプトコンテンツのレスポンスをマッピングするインターフェース
+        private readonly IPromptCreateResponseMapper _promptCreateResponseMapper;
+
+        // パラメータ名
+        private const string ParamName = "promptContent";
+
+
+        public PromptContentRepository(ILogger<ProjectsRepository> logger, IAuthenticationTokenizer authenticationTokenizer, IAccounApitAccess accountAccess, IAccountRepository accountRepository, IApiResourceConfigurations apiResourceConfigurations, IPromptContentApiAccess promptContentApiAccess, IPromptCreateResponseMapper promptCreateResponseMapper)
+        {
+            _logger = logger;
+            _authenticationTokenizer = authenticationTokenizer;
+            _accountAccess = accountAccess;
+            _accountRepository = accountRepository;
+            _apiResourceConfigurations = apiResourceConfigurations;
+            _promptContentApiAccess = promptContentApiAccess;
+            _promptCreateResponseMapper = promptCreateResponseMapper;
+        }
+
+
+        public async Task<PromptCreateResponseModel?> GetPromptContentAsync(PromptContentRequestModel requestModel)
+        {
+            // アカウント情報を取得し、存在しない場合は例外をスロー
+            var account = await _accountAccess.GetAccountAsync(_apiResourceConfigurations.ViAccountName) ?? throw new ArgumentNullException(paramName: ParamName);
+
+            // アカウント情報のチェック
+            _accountRepository.CheckAccount(account);
+
+            // アカウントのロケーションとIDを取得
+            string? location = account.location;
+            string? accountId = account.properties?.id;
+
+            // アクセストークンを取得
+            string accessToken = await _authenticationTokenizer.GetAccessToken();
+
+            // プロンプトコンテンツを取得
+            return await GetPromptContentAsync(location!, accountId!, requestModel, accessToken);
+        }
+
+        public async Task<PromptCreateResponseModel?> GetPromptContentAsync(string location, string accountId, PromptContentRequestModel requestModel, string? accessToken = null)
+        {
+            try
+            {
+                // アクセストークンが指定されていない場合は取得
+                if (string.IsNullOrEmpty(accessToken))
+                {
+                    accessToken = await _authenticationTokenizer.GetAccessToken();
+                }
+                // アカウント情報を取得
+                var account = await _accountAccess.GetAccountAsync(accountId);
+                if (account == null)
+                {
+                    _logger.LogError("Account not found: {AccountId}", accountId);
+                    return null;
+                }
+                // プロンプトコンテンツを取得
+                ApiPromptCreateResponseModel? promptContent = await _promptContentApiAccess.GetPromptContentAsync(location, accountId, requestModel.VideoId, requestModel.ModelName, requestModel.PromptStyle, accessToken);
+
+                return promptContent is null ? null : _promptCreateResponseMapper.MapFrom(promptContent);
+            }
+            catch (ArgumentException ex)
+            {
+                _logger.LogError(ex, "Argument error occurred. Location: {Location}, AccountId: {AccountId}, video {VideoId} in account {AccountId}", location, accountId, requestModel.VideoId, accountId);
+                throw;
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "API request failed. Location: {Location}, AccountId: {AccountId}, video {VideoId} in account {AccountId}", location, accountId, requestModel.VideoId, accountId);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get prompt content: {Location}, AccountId: {AccountId}, video {VideoId} in account {AccountId}", location, accountId, requestModel.VideoId, accountId);
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
新しいインターフェース `IPromptCreateResponseMapper` とその実装 `PromptCreateResponseMapper` を追加し、APIモデルとデータモデル間のマッピング機能を提供しました。これにより、`ApiPromptCreateResponseModel` と `PromptCreateResponseModel` の間でデータを変換するメソッドが実装されています。

また、`PromptContentRequestModel` クラスと `PromptCreateResponseModel` クラスを追加し、それぞれビデオID、モデル名、プロンプトスタイル、エラータイプ、メッセージを保持するプロパティを定義しました。

さらに、`PromptContentRepository` クラスにプロンプトコンテンツを取得するメソッドを追加し、取得したデータを `IPromptCreateResponseMapper` を使用してマッピングする処理を組み込みました。