### PR TITLE
ビデオ削除機能の実装と結果マッピングの追加

### DIFF
--- a/VideoIndexerAccess/Repositories/DataModel/DeleteVideoResultModel.cs
+++ b/VideoIndexerAccess/Repositories/DataModel/DeleteVideoResultModel.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VideoIndexerAccess.Repositories.DataModel
+{
+    public class DeleteVideoResultModel
+    {
+        public string[]? FailedAssets { get; set; }
+    }
+}

--- a/VideoIndexerAccess/Repositories/DataModelMapper/DeleteVideoResultMapper.cs
+++ b/VideoIndexerAccess/Repositories/DataModelMapper/DeleteVideoResultMapper.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VideoIndexerAccess.Repositories.DataModel;
+using VideoIndexerAccessCore.VideoIndexerClient.ApiModel;
+
+namespace VideoIndexerAccess.Repositories.DataModelMapper
+{
+    public class DeleteVideoResultMapper : IDeleteVideoResultMapper
+    {
+        public DeleteVideoResultModel MapFrom(ApiDeleteVideoResultModel model)
+        {
+            return new DeleteVideoResultModel
+            {
+                FailedAssets = model.failedAssets?.ToArray(),
+            };
+        }
+
+        public ApiDeleteVideoResultModel MapToApiDeleteVideoResultModel(DeleteVideoResultModel model)
+        {
+            return new ApiDeleteVideoResultModel
+            {
+                failedAssets = model.FailedAssets?.ToArray(),
+            };
+        }
+    }
+}

--- a/VideoIndexerAccess/Repositories/DataModelMapper/IDeleteVideoResultMapper.cs
+++ b/VideoIndexerAccess/Repositories/DataModelMapper/IDeleteVideoResultMapper.cs
@@ -1,0 +1,10 @@
+﻿using VideoIndexerAccess.Repositories.DataModel;
+using VideoIndexerAccessCore.VideoIndexerClient.ApiModel;
+
+namespace VideoIndexerAccess.Repositories.DataModelMapper;
+
+public interface IDeleteVideoResultMapper
+{
+    DeleteVideoResultModel MapFrom(ApiDeleteVideoResultModel model);
+    ApiDeleteVideoResultModel MapToApiDeleteVideoResultModel(DeleteVideoResultModel model);
+}

--- a/VideoIndexerAccess/Repositories/VideoItemRepository/VideosRepository.cs
+++ b/VideoIndexerAccess/Repositories/VideoItemRepository/VideosRepository.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using VideoIndexerAccess.Repositories.AuthorizAccess;
+using VideoIndexerAccess.Repositories.DataModel;
+using VideoIndexerAccess.Repositories.DataModelMapper;
 using VideoIndexerAccessCore.VideoIndexerClient.ApiAccess;
 using VideoIndexerAccessCore.VideoIndexerClient.ApiModel;
 using VideoIndexerAccessCore.VideoIndexerClient.Configuration;
@@ -35,13 +37,57 @@ namespace VideoIndexerAccess.Repositories.VideoItemRepository
         private const string ParamName = "videos";
 
         // マッパーインターフェース
+        private readonly IDeleteVideoResultMapper _deleteVideoResultMapper;
 
-
-        public async Task<ApiDeleteVideoResultModel?> DeleteVideoAsync(string location, string accountId, string videoId, string? accessToken = null)
+        public VideosRepository(ILogger<VideosRepository> logger, IAuthenticationTokenizer authenticationTokenizer, IAccounApitAccess accountAccess, IAccountRepository accountRepository, IApiResourceConfigurations apiResourceConfigurations, IVideosApiAccess videosApiAccess, IVideoDownloadApiAccess videoDownloadApiAccess, IDeleteVideoResultMapper deleteVideoResultMapper)
         {
-            // tobo
-            throw new NotImplementedException("DeleteVideoAsync method is not implemented yet.");
+            _logger = logger;
+            _authenticationTokenizer = authenticationTokenizer;
+            _accountAccess = accountAccess;
+            _accountRepository = accountRepository;
+            _apiResourceConfigurations = apiResourceConfigurations;
+            _videosApiAccess = videosApiAccess;
+            _videoDownloadApiAccess = videoDownloadApiAccess;
+            _deleteVideoResultMapper = deleteVideoResultMapper;
         }
 
+        /// <summary>
+        /// 指定されたビデオを削除します。
+        /// </summary>
+        /// <param name="videoId">削除対象のビデオID</param>
+        /// <returns>削除結果を示す <see cref="DeleteVideoResultModel"/> オブジェクト</returns>
+        /// <exception cref="ArgumentNullException">アカウント情報が取得できない場合にスローされます。</exception>
+        public async Task<DeleteVideoResultModel?> DeleteVideoAsync(string videoId)
+        {
+            // アカウント情報を取得し、存在しない場合は例外をスロー
+            var account = await _accountAccess.GetAccountAsync(_apiResourceConfigurations.ViAccountName) ?? throw new ArgumentNullException(paramName: ParamName);
+
+            // アカウント情報のチェック
+            _accountRepository.CheckAccount(account);
+
+            // アカウントのロケーションとIDを取得
+            string? location = account.location;
+            string? accountId = account.properties?.id;
+
+            // アクセストークンを取得
+            string accessToken = await _authenticationTokenizer.GetAccessToken();
+
+            // ビデオを削除する
+            return await DeleteVideoAsync(location!, accountId!, videoId, accessToken);
+        }
+
+        /// <summary>
+        /// 指定されたロケーション、アカウントID、ビデオIDを使用してビデオを削除します。
+        /// </summary>
+        /// <param name="location">Azureリージョン名</param>
+        /// <param name="accountId">Video IndexerアカウントID</param>
+        /// <param name="videoId">削除対象のビデオID</param>
+        /// <param name="accessToken">アクセストークン（省略可能）</param>
+        /// <returns>削除結果を示す <see cref="DeleteVideoResultModel"/> オブジェクト</returns>
+        public async Task<DeleteVideoResultModel?> DeleteVideoAsync(string location, string accountId, string videoId, string? accessToken = null)
+        {
+            ApiDeleteVideoResultModel? resultModel = await _videosApiAccess.DeleteVideoAsync(location, accountId, videoId, accessToken);
+            return resultModel is null ? null : _deleteVideoResultMapper.MapFrom(resultModel);
+        }
     }
 }


### PR DESCRIPTION
`VideosRepository.cs` に `IDeleteVideoResultMapper` インターフェースとその実装を追加し、ビデオ削除の結果をマッピングする機能を実装しました。`DeleteVideoAsync` メソッドのオーバーロードを追加し、アカウント情報を取得してビデオを削除する処理を実装しました。

`DeleteVideoResultMapper.cs` では、APIからの削除結果をアプリケーション内のモデルにマッピングする `DeleteVideoResultMapper` クラスを追加しました。

`IDeleteVideoResultMapper.cs` では、削除結果をマッピングするためのインターフェースを定義しました。

`DeleteVideoResultModel.cs` では、削除結果を表すモデルクラスを追加し、削除に失敗したアセットの配列を保持するプロパティを定義しました。