### PR TITLE
ビデオ削除機能のコメント追加と新メソッド追加

### DIFF
--- a/VideoIndexerAccess/Repositories/VideoItemRepository/VideosRepository.cs
+++ b/VideoIndexerAccess/Repositories/VideoItemRepository/VideosRepository.cs
@@ -53,6 +53,8 @@ namespace VideoIndexerAccess.Repositories.VideoItemRepository
 
         /// <summary>
         /// 指定されたビデオを削除します。
+        /// Delete Video
+        /// Deletes the specified video and all related insights created from when the video was indexed
         /// </summary>
         /// <param name="videoId">削除対象のビデオID</param>
         /// <returns>削除結果を示す <see cref="DeleteVideoResultModel"/> オブジェクト</returns>
@@ -78,6 +80,8 @@ namespace VideoIndexerAccess.Repositories.VideoItemRepository
 
         /// <summary>
         /// 指定されたロケーション、アカウントID、ビデオIDを使用してビデオを削除します。
+        /// Delete Video
+        /// Deletes the specified video and all related insights created from when the video was indexed
         /// </summary>
         /// <param name="location">Azureリージョン名</param>
         /// <param name="accountId">Video IndexerアカウントID</param>
@@ -89,5 +93,43 @@ namespace VideoIndexerAccess.Repositories.VideoItemRepository
             ApiDeleteVideoResultModel? resultModel = await _videosApiAccess.DeleteVideoAsync(location, accountId, videoId, accessToken);
             return resultModel is null ? null : _deleteVideoResultMapper.MapFrom(resultModel);
         }
+        /// <summary>
+        /// 指定されたビデオのソースファイルを削除します。
+        /// Delete Video Source File
+        /// </summary>
+        /// <param name="videoId">ソースファイルを削除するビデオのID</param>
+        /// <returns>削除に成功した場合は true、失敗や例外発生時には false を返します。</returns>
+        public async Task<bool> DeleteVideoSourceFileAsync(string videoId)
+        {
+            // アカウント情報を取得し、存在しない場合は例外をスロー
+            var account = await _accountAccess.GetAccountAsync(_apiResourceConfigurations.ViAccountName) ?? throw new ArgumentNullException(paramName: ParamName);
+            // アカウント情報のチェック
+            _accountRepository.CheckAccount(account);
+            // アカウントのロケーションとIDを取得
+            string? location = account.location;
+            string? accountId = account.properties?.id;
+            // アクセストークンを取得
+            string accessToken = await _authenticationTokenizer.GetAccessToken();
+            // ビデオソースファイルを削除する
+            return await DeleteVideoSourceFileAsync(location!, accountId!, videoId, accessToken);
+        }
+        
+        /// <summary>
+        /// 指定された動画のソースファイルとストリーミングアセットを削除します（インサイトは保持）。
+        /// Delete Video Source File
+        /// https://api-portal.videoindexer.ai/api-details#api=Operations&operation=Delete-Video-Source-File
+        /// </summary>
+        /// <param name="location">Azure リージョン名（例: "japaneast"、"westus" など）</param>
+        /// <param name="accountId">Video Indexer アカウントの一意な GUID 文字列</param>
+        /// <param name="videoId">ソースファイルを削除するビデオの ID</param>
+        /// <param name="accessToken">アクセストークン（省略可能）</param>
+        /// <returns>
+        /// 削除に成功した場合は true を返し、失敗や例外発生時には false を返します。
+        /// </returns>
+        public async Task<bool> DeleteVideoSourceFileAsync(string location, string accountId, string videoId, string? accessToken = null)
+        {
+            return await _videosApiAccess.DeleteVideoSourceFileAsync(location, accountId, videoId, accessToken);
+        }
+
     }
 }


### PR DESCRIPTION
This pull request updates the `VideosRepository` class in the `VideoIndexerAccess` module to enhance its video deletion functionality. The changes include adding new methods for deleting video source files, improving documentation, and ensuring proper handling of account information during operations.

### Enhancements to video deletion functionality:

* Added the `DeleteVideoSourceFileAsync` method to delete a video's source file and streaming assets while retaining insights. This includes logic to fetch account information, validate it, and perform the deletion using the Video Indexer API. (`[VideoIndexerAccess/Repositories/VideoItemRepository/VideosRepository.csR96-R133](diffhunk://#diff-9a2f25640b7343d579f4a70d78ee6ce0e7ebb229721e7e288f486bb7e3ae86abR96-R133)`)
* Added an overload of the `DeleteVideoSourceFileAsync` method to handle deletion with specified parameters like location, account ID, video ID, and access token. (`[VideoIndexerAccess/Repositories/VideoItemRepository/VideosRepository.csR96-R133](diffhunk://#diff-9a2f25640b7343d579f4a70d78ee6ce0e7ebb229721e7e288f486bb7e3ae86abR96-R133)`)

### Documentation improvements:

* Updated XML comments for the `DeleteVideo` method to clarify that it deletes the specified video along with all related insights created during indexing. (`[[1]](diffhunk://#diff-9a2f25640b7343d579f4a70d78ee6ce0e7ebb229721e7e288f486bb7e3ae86abR56-R57)`, `[[2]](diffhunk://#diff-9a2f25640b7343d579f4a70d78ee6ce0e7ebb229721e7e288f486bb7e3ae86abR83-R84)`)`DeleteVideoAsync` 
* 
* メソッドに関するコメントを追加し、指定されたビデオのソースファイルを削除する `DeleteVideoSourceFileAsync` メソッドを新たに実装しました。これにより、ビデオソースファイル削除機能が強化され、関連するパラメータや戻り値の説明も追加されています。