### PR TITLE
アーティファクト関連の機能を追加

### DIFF
--- a/VideoIndexerAccess/Repositories/DataModel/ArtifactType.cs
+++ b/VideoIndexerAccess/Repositories/DataModel/ArtifactType.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VideoIndexerAccess.Repositories.DataModel
+{
+    public enum ArtifactType
+    {
+        Ocr,
+        Faces,
+        FacesThumbnails,
+        VisualContentModeration,
+        KeyframesThumbnails,
+        Emotions,
+        TextualContentModeration,
+        AudioEffects,
+        ObservedPeople,
+        Labels,
+        Transcript,
+        FeaturedClothing,
+        Clapperboards,
+        DigitalPatterns,
+        TextlessMaterial,
+        Logos,
+        DetectedObjects
+    }
+}

--- a/VideoIndexerAccess/Repositories/DataModel/ArtifactTypeMapper.cs
+++ b/VideoIndexerAccess/Repositories/DataModel/ArtifactTypeMapper.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VideoIndexerAccess.Repositories.DataModel
+{
+    public class ArtifactTypeMapper : IArtifactTypeMapper
+    {
+        private static readonly Dictionary<string, ArtifactType> NameToType = Enum.GetValues<ArtifactType>().ToDictionary(e => e.ToString(), e => e, StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// 指定されたメンバー名から <see cref="ArtifactType"/> へのマッピングを試みます。
+        /// </summary>
+        /// <param name="memberName">マッピングするメンバー名。</param>
+        /// <param name="artifactType">マッピングされた <see cref="ArtifactType"/>。失敗した場合は既定値。</param>
+        /// <returns>マッピングに成功した場合は true、それ以外は false。</returns>
+        public bool TryMap(string memberName, out ArtifactType artifactType)
+        {
+            if (string.IsNullOrWhiteSpace(memberName))
+            {
+                artifactType = default;
+                return false;
+            }
+
+            return NameToType.TryGetValue(memberName, out artifactType);
+        }
+
+        /// <summary>
+        /// 指定されたメンバー名から <see cref="ArtifactType"/> へマッピングします。
+        /// マッピングに失敗した場合は <see cref="ArgumentException"/> をスローします。
+        /// </summary>
+        /// <param name="memberName">マッピングするメンバー名。</param>
+        /// <returns>マッピングされた <see cref="ArtifactType"/>。</returns>
+        /// <exception cref="ArgumentException">無効なメンバー名が指定された場合。</exception>
+        public ArtifactType MapFrom(string memberName) => TryMap(memberName, out var artifactType) ? artifactType : throw new ArgumentException($"Invalid ArtifactType name: {memberName}", nameof(memberName));
+
+        /// <summary>
+        /// 指定された <see cref="ArtifactType"/> を文字列に変換します。
+        /// 無効な値が指定された場合は <see cref="ArgumentException"/> をスローします。
+        /// </summary>
+        /// <param name="artifactType">変換する <see cref="ArtifactType"/>。</param>
+        /// <returns>文字列に変換された <see cref="ArtifactType"/>。</returns>
+        /// <exception cref="ArgumentException">無効な <see cref="ArtifactType"/> 値が指定された場合。</exception>
+        public string MapToString(ArtifactType artifactType)
+        {
+            if (!Enum.IsDefined(typeof(ArtifactType), artifactType)) throw new ArgumentException($"Invalid ArtifactType value: {artifactType}", nameof(artifactType));
+            return artifactType.ToString();
+        }
+    }
+}

--- a/VideoIndexerAccess/Repositories/DataModel/GetVideoCaptionsRequestModel.cs
+++ b/VideoIndexerAccess/Repositories/DataModel/GetVideoCaptionsRequestModel.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VideoIndexerAccess.Repositories.DataModel
+{
+    public class GetVideoCaptionsRequestModel
+    {
+        public required string VideoId { get; set; }
+        public string? IndexId { get; set; } = null;
+        public string? Format { get; set; } = null;
+        public string? Language { get; set; } = null;
+        public bool? IncludeAudioEffects { get; set; } = null;
+        public bool? IncludeSpeakers { get; set; } = null;
+    }
+}

--- a/VideoIndexerAccess/Repositories/DataModel/IArtifactTypeMapper.cs
+++ b/VideoIndexerAccess/Repositories/DataModel/IArtifactTypeMapper.cs
@@ -1,0 +1,30 @@
+﻿namespace VideoIndexerAccess.Repositories.DataModel;
+
+public interface IArtifactTypeMapper
+{
+    /// <summary>
+    /// 指定されたメンバー名から <see cref="ArtifactType"/> へのマッピングを試みます。
+    /// </summary>
+    /// <param name="memberName">マッピングするメンバー名。</param>
+    /// <param name="artifactType">マッピングされた <see cref="ArtifactType"/>。失敗した場合は既定値。</param>
+    /// <returns>マッピングに成功した場合は true、それ以外は false。</returns>
+    bool TryMap(string memberName, out ArtifactType artifactType);
+
+    /// <summary>
+    /// 指定されたメンバー名から <see cref="ArtifactType"/> へマッピングします。
+    /// マッピングに失敗した場合は <see cref="ArgumentException"/> をスローします。
+    /// </summary>
+    /// <param name="memberName">マッピングするメンバー名。</param>
+    /// <returns>マッピングされた <see cref="ArtifactType"/>。</returns>
+    /// <exception cref="ArgumentException">無効なメンバー名が指定された場合。</exception>
+    ArtifactType MapFrom(string memberName);
+
+    /// <summary>
+    /// 指定された <see cref="ArtifactType"/> を文字列に変換します。
+    /// 無効な値が指定された場合は <see cref="ArgumentException"/> をスローします。
+    /// </summary>
+    /// <param name="artifactType">変換する <see cref="ArtifactType"/>。</param>
+    /// <returns>文字列に変換された <see cref="ArtifactType"/>。</returns>
+    /// <exception cref="ArgumentException">無効な <see cref="ArtifactType"/> 値が指定された場合。</exception>
+    string MapToString(ArtifactType artifactType);
+}

--- a/VideoIndexerAccessCore/VideoIndexerClient/ApiAccess/VideosApiAccess.cs
+++ b/VideoIndexerAccessCore/VideoIndexerClient/ApiAccess/VideosApiAccess.cs
@@ -250,16 +250,7 @@ namespace VideoIndexerAccessCore.VideoIndexerClient.ApiAccess
         /// <param name="includeSpeakers">話者情報を含めるか（true/false）</param>
         /// <param name="accessToken">アクセストークン（省略可能だが、必要な場合あり）</param>
         /// <returns>取得された字幕データ（文字列）を返します。失敗時は null。</returns>
-        public async Task<string?> GetVideoCaptionsAsync(
-            string location,
-            string accountId,
-            string videoId,
-            string? indexId = null,
-            string? format = null,
-            string? language = null,
-            bool? includeAudioEffects = null,
-            bool? includeSpeakers = null,
-            string? accessToken = null)
+        public async Task<string?> GetVideoCaptionsAsync(string location, string accountId, string videoId, string? indexId = null, string? format = null, string? language = null, bool? includeAudioEffects = null, bool? includeSpeakers = null, string? accessToken = null)
         {
             try
             {


### PR DESCRIPTION
`VideosRepository` に `IArtifactTypeMapper` を追加し、ビデオアーティファクトのダウンロード URL を取得するメソッドを実装。 新たに `ArtifactType` 列挙型と `ArtifactTypeMapper` クラスを追加し、アーティファクトの種類を管理。 ビデオのキャプション取得用のリクエストモデルと、マッピングインターフェースも追加。