### PR TITLE
ストリーミング URL マッピング機能を追加

### DIFF
--- a/VideoIndexerAccess/Repositories/DataModel/StreamingUrlModel.cs
+++ b/VideoIndexerAccess/Repositories/DataModel/StreamingUrlModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VideoIndexerAccess.Repositories.DataModel
+{
+    public class StreamingUrlModel
+    {
+        public string? Url { get; set; }
+        public string? Jwt { get; set; }
+    }
+}

--- a/VideoIndexerAccess/Repositories/DataModelMapper/IStreamingUrlMapper.cs
+++ b/VideoIndexerAccess/Repositories/DataModelMapper/IStreamingUrlMapper.cs
@@ -1,0 +1,10 @@
+﻿using VideoIndexerAccess.Repositories.DataModel;
+using VideoIndexerAccessCore.VideoIndexerClient.ApiModel;
+
+namespace VideoIndexerAccess.Repositories.DataModelMapper;
+
+public interface IStreamingUrlMapper
+{
+    StreamingUrlModel MapFrom(ApiStreamingUrlModel model);
+    ApiStreamingUrlModel MapTo(StreamingUrlModel model);
+}

--- a/VideoIndexerAccess/Repositories/DataModelMapper/StreamingUrlMapper.cs
+++ b/VideoIndexerAccess/Repositories/DataModelMapper/StreamingUrlMapper.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VideoIndexerAccess.Repositories.DataModel;
+using VideoIndexerAccessCore.VideoIndexerClient.ApiModel;
+
+namespace VideoIndexerAccess.Repositories.DataModelMapper
+{
+    public class StreamingUrlMapper : IStreamingUrlMapper
+    {
+        public StreamingUrlModel MapFrom(ApiStreamingUrlModel model)
+        {
+            return new StreamingUrlModel
+            {
+                Url = model.url,
+                Jwt = model.jwt
+            };
+        }
+
+        public ApiStreamingUrlModel MapTo(StreamingUrlModel model)
+        {
+            return new ApiStreamingUrlModel
+            {
+                url = model.Url,
+                jwt = model.Jwt
+            };
+        }
+    }
+}


### PR DESCRIPTION
`VideosRepository.cs` に `IStreamingUrlMapper` を追加し、ストリーミング URL の処理を改善しました。`GetVideoStreamingUrlAsync` メソッドの戻り値の型を変更し、マッパーを使用して変換を行うようにしました。

新たに `IStreamingUrlMapper` インターフェースを定義し、`StreamingUrlMapper` で実装しました。また、ストリーミング URL と JWT トークンを保持する `StreamingUrlModel` データモデルを追加しました。