### PR TITLE
メソッドの構文修正

### DIFF
--- a/VideoIndexerAccess/Repositories/VideoItemRepository/VideosRepository.cs
+++ b/VideoIndexerAccess/Repositories/VideoItemRepository/VideosRepository.cs
@@ -633,6 +633,5 @@ namespace VideoIndexerAccess.Repositories.VideoItemRepository
         {
             return await _videosApiAccess.UpdateVideoTranscriptAsync(location, accountId, request.VideoId, request.VttContent, request.Language, request.SetAsSourceLanguage, request.CallbackUrl, request.SendSuccessEmail, accessToken);
         }
-
-}
+    }
 }


### PR DESCRIPTION
`UpdateVideoTranscriptAsync` メソッドの終了部分に余分な閉じ波括弧 `}` が追加され、構文が修正されました。