### PR TITLE
ウィジェット情報取得機能の強化

### DIFF
--- a/VideoIndexerAccess/Repositories/DataModel/GetVideoInsightsWidgetResponseModel.cs
+++ b/VideoIndexerAccess/Repositories/DataModel/GetVideoInsightsWidgetResponseModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VideoIndexerAccess.Repositories.DataModel
+{
+    public class GetVideoInsightsWidgetResponseModel
+    {
+        public required string VideoId { get; set; }
+        public string? WidgetType { get; set; }
+        public bool? AllowEdit { get; set; }
+    }
+}

--- a/VideoIndexerAccess/Repositories/DataModel/VideoInsightsWidgetResponseModel.cs
+++ b/VideoIndexerAccess/Repositories/DataModel/VideoInsightsWidgetResponseModel.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VideoIndexerAccess.Repositories.DataModel
+{
+    public class VideoInsightsWidgetResponseModel
+    {
+        /// <summary>
+        /// ウィジェット表示用のURL（リダイレクト先など）
+        /// </summary>
+        public string? WidgetUrl { get; set; }
+
+        /// <summary>
+        /// エラー時のタイプ（例：GENERAL, USER_NOT_ALLOWEDなど）
+        /// </summary>
+        public string? ErrorType { get; set; }
+
+        /// <summary>
+        /// エラーに関する詳細メッセージ
+        /// </summary>
+        public string? Message { get; set; }
+
+        /// <summary>
+        /// サーバーからのリクエストID（ログ調査などに利用）
+        /// </summary>
+        public string? RequestId { get; set; }
+    }
+}

--- a/VideoIndexerAccess/Repositories/DataModelMapper/IVideoInsightsWidgetResponseMapper.cs
+++ b/VideoIndexerAccess/Repositories/DataModelMapper/IVideoInsightsWidgetResponseMapper.cs
@@ -1,0 +1,10 @@
+﻿using VideoIndexerAccess.Repositories.DataModel;
+using VideoIndexerAccessCore.VideoIndexerClient.ApiModel;
+
+namespace VideoIndexerAccess.Repositories.DataModelMapper;
+
+public interface IVideoInsightsWidgetResponseMapper
+{
+    VideoInsightsWidgetResponseModel MapFrom(ApiVideoInsightsWidgetResponseModel model);
+    ApiVideoInsightsWidgetResponseModel MapToApiVideoInsightsWidgetResponseModel(VideoInsightsWidgetResponseModel model);
+}

--- a/VideoIndexerAccess/Repositories/DataModelMapper/VideoInsightsWidgetResponseMapper.cs
+++ b/VideoIndexerAccess/Repositories/DataModelMapper/VideoInsightsWidgetResponseMapper.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VideoIndexerAccess.Repositories.DataModel;
+using VideoIndexerAccessCore.VideoIndexerClient.ApiModel;
+
+namespace VideoIndexerAccess.Repositories.DataModelMapper
+{
+    public class VideoInsightsWidgetResponseMapper : IVideoInsightsWidgetResponseMapper
+    {
+        public VideoInsightsWidgetResponseModel MapFrom(ApiVideoInsightsWidgetResponseModel model)
+        {
+            if (model == null) throw new ArgumentNullException(nameof(model));
+            return new VideoInsightsWidgetResponseModel
+            {
+                WidgetUrl = model.widgetUrl,
+                ErrorType = model.errorType,
+                Message = model.message,
+                RequestId = model.requestId
+            };
+        }
+
+        public ApiVideoInsightsWidgetResponseModel MapToApiVideoInsightsWidgetResponseModel(VideoInsightsWidgetResponseModel model)
+        {
+            if (model == null) throw new ArgumentNullException(nameof(model));
+            return new ApiVideoInsightsWidgetResponseModel
+            {
+                widgetUrl = model.WidgetUrl,
+                errorType = model.ErrorType,
+                message = model.Message,
+                requestId = model.RequestId
+            };
+        }
+    }
+}

--- a/VideoIndexerAccess/Repositories/VideoItemRepository/WidgetRepository.cs
+++ b/VideoIndexerAccess/Repositories/VideoItemRepository/WidgetRepository.cs
@@ -1,6 +1,14 @@
 ﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 using VideoIndexerAccess.Repositories.AuthorizAccess;
+using VideoIndexerAccess.Repositories.DataModel;
+using VideoIndexerAccess.Repositories.DataModelMapper;
 using VideoIndexerAccessCore.VideoIndexerClient.ApiAccess;
+using VideoIndexerAccessCore.VideoIndexerClient.ApiModel;
 using VideoIndexerAccessCore.VideoIndexerClient.Configuration;
 
 namespace VideoIndexerAccess.Repositories.VideoItemRepository
@@ -27,8 +35,9 @@ namespace VideoIndexerAccess.Repositories.VideoItemRepository
         private const string ParamName = "widget";
 
         // マッパーインターフェース
+        private readonly IVideoInsightsWidgetResponseMapper _insightsWidgetResponseMapper;
 
-        public WidgetRepository(ILogger<WidgetRepository> logger, IAuthenticationTokenizer authenticationTokenizer, IAccounApitAccess accountAccess, IAccountRepository accountRepository, IApiResourceConfigurations apiResourceConfigurations, IWidgetsApiAccess widgetsApiAccess)
+        public WidgetRepository(ILogger<WidgetRepository> logger, IAuthenticationTokenizer authenticationTokenizer, IAccounApitAccess accountAccess, IAccountRepository accountRepository, IApiResourceConfigurations apiResourceConfigurations, IWidgetsApiAccess widgetsApiAccess, IVideoInsightsWidgetResponseMapper insightsWidgetResponseMapper)
         {
             _logger = logger;
             _authenticationTokenizer = authenticationTokenizer;
@@ -36,6 +45,160 @@ namespace VideoIndexerAccess.Repositories.VideoItemRepository
             _accountRepository = accountRepository;
             _apiResourceConfigurations = apiResourceConfigurations;
             _widgetsApiAccess = widgetsApiAccess;
+            _insightsWidgetResponseMapper = insightsWidgetResponseMapper;
+        }
+
+
+        public async Task<string?> GetVideoInsightsWidgetUrl(GetVideoInsightsWidgetResponseModel requestModel)
+        {
+            // アカウント情報を取得し、存在しない場合は例外をスロー
+            var account = await _accountAccess.GetAccountAsync(_apiResourceConfigurations.ViAccountName) ?? throw new ArgumentNullException(paramName: ParamName);
+
+            // アカウント情報のチェック
+            _accountRepository.CheckAccount(account);
+
+            // アカウントのロケーションとIDを取得
+            string? location = account.location;
+            string? accountId = account.properties?.id;
+
+            // アクセストークンを取得
+            string accessToken = await _authenticationTokenizer.GetAccessToken();
+
+            // Insights Widget のURLを取得
+            return await GetVideoInsightsWidgetUrl(location!, accountId!, requestModel, accessToken);
+        }
+
+        /// <summary>
+        /// Insights Widget のURLを取得します。
+        /// Video Indexer API から Insights Widget のリダイレクトURLを取得し返却します。
+        /// </summary>
+        /// <param name="location">API呼び出し先のリージョン（例：trial）</param>
+        /// <param name="accountId">Video Indexer アカウントの GUID</param>
+        /// <param name="requestModel"></param>
+        /// <param name="accessToken">（任意）アクセストークン。編集やプライベートビデオの場合に必要</param>
+        /// <returns>リダイレクトされた Insights Widget のURL。失敗時は null</returns>
+        public async Task<string?> GetVideoInsightsWidgetUrl(string location, string accountId, GetVideoInsightsWidgetResponseModel requestModel, string? accessToken = null)
+        {
+            return await _widgetsApiAccess.GetVideoInsightsWidgetUrl(location, accountId, requestModel.VideoId, requestModel.WidgetType, requestModel.AllowEdit, accessToken);
+        }
+
+
+        /// <summary>
+        /// Insights Widget の情報を取得します。
+        /// アカウント情報の取得、検証、アクセストークンの取得を行い、Insights Widget API から情報を取得します。
+        /// </summary>
+        /// <param name="requestModel">ウィジェット情報取得用リクエストモデル</param>
+        /// <returns>ウィジェット情報を格納した <see cref="ApiVideoInsightsWidgetResponseModel"/> インスタンス。失敗時は null</returns>
+        public async Task<VideoInsightsWidgetResponseModel?> GetVideoInsightsWidgetAsync(GetVideoInsightsWidgetResponseModel requestModel)
+        {
+            // アカウント情報を取得し、存在しない場合は例外をスロー
+            var account = await _accountAccess.GetAccountAsync(_apiResourceConfigurations.ViAccountName) ?? throw new ArgumentNullException(paramName: ParamName);
+
+            // アカウント情報のチェック
+            _accountRepository.CheckAccount(account);
+
+            // アカウントのロケーションとIDを取得
+            string? location = account.location;
+            string? accountId = account.properties?.id;
+
+            // アクセストークンを取得
+            string accessToken = await _authenticationTokenizer.GetAccessToken();
+
+            // ウィジェット情報を取得
+            return await GetVideoInsightsWidgetAsync(location!, accountId!, requestModel, accessToken);
+        }
+
+        /// <summary>
+        /// Insights Widget の情報を取得します。
+        /// </summary>
+        /// <param name="requestModel">ウィジェット情報取得用リクエストモデル</param>
+        /// <param name="location">API呼び出し先のリージョン（例：trial）</param>
+        /// <param name="accountId">Video Indexer アカウントの GUID</param>
+        /// <param name="accessToken">（任意）アクセストークン。編集やプライベートビデオの場合に必要</param>
+        /// <returns>ウィジェット情報を格納した <see cref="ApiVideoInsightsWidgetResponseModel"/> インスタンス。失敗時は null</returns>
+        public async Task<VideoInsightsWidgetResponseModel?> GetVideoInsightsWidgetAsync(string location, string accountId, GetVideoInsightsWidgetResponseModel requestModel, string? accessToken = null)
+        {
+            ApiVideoInsightsWidgetResponseModel? widgetResponse = await _widgetsApiAccess.GetVideoInsightsWidgetAsync(location, accountId, requestModel.VideoId, requestModel.WidgetType, requestModel.AllowEdit, accessToken);
+            return widgetResponse is null ? null : _insightsWidgetResponseMapper.MapFrom(widgetResponse);
+        }
+
+        /// <summary>
+        /// Video Player Widget のURLを取得します。
+        /// アカウント情報の取得、検証、アクセストークンの取得を行い、Video Player Widget API からリダイレクトURLを取得します。
+        /// </summary>
+        /// <param name="videoId">対象のビデオID</param>
+        /// <returns>リダイレクトされた Player Widget のURL。失敗時は null</returns>
+        public async Task<string?> GetVideoPlayerWidgetUrl(string videoId)
+        {
+            // アカウント情報を取得し、存在しない場合は例外をスロー
+            var account = await _accountAccess.GetAccountAsync(_apiResourceConfigurations.ViAccountName) ?? throw new ArgumentNullException(paramName: ParamName);
+
+            // アカウント情報のチェック
+            _accountRepository.CheckAccount(account);
+
+            // アカウントのロケーションとIDを取得
+            string? location = account.location;
+            string? accountId = account.properties?.id;
+
+            // アクセストークンを取得
+            string accessToken = await _authenticationTokenizer.GetAccessToken();
+
+            // Video Player Widget のURLを取得
+            return await GetVideoPlayerWidgetUrl(location!, accountId!, videoId, accessToken);
+        }
+
+
+        /// <summary>
+        /// Video Player Widget のリダイレクトURLを取得します。
+        /// Video Indexer API から Player Widget のリダイレクトURLを取得し返却します。
+        /// </summary>
+        /// <param name="location">API呼び出し先のリージョン（例：trial）</param>
+        /// <param name="accountId">Video Indexer アカウントの GUID</param>
+        /// <param name="videoId">対象のビデオID</param>
+        /// <param name="accessToken">（任意）アクセストークン。プライベートビデオなどに必要</param>
+        /// <returns>リダイレクトされた Player Widget のURL。失敗時は null</returns>
+        public async Task<string?> GetVideoPlayerWidgetUrl(string location, string accountId, string videoId, string? accessToken = null)
+        {
+            return await _widgetsApiAccess.GetVideoPlayerWidgetUrl(location, accountId, videoId, accessToken);
+        }
+
+
+        /// <summary>
+        /// Video Player Widget の情報を取得します。
+        /// アカウント情報の取得、検証、アクセストークンの取得を行い、Video Player Widget API から情報を取得します。
+        /// </summary>
+        /// <param name="videoId">対象のビデオID</param>
+        /// <returns>Player Widget URLを格納した <see cref="ApiVideoPlayerWidgetResponseModel"/>。失敗時は null</returns>
+        public async Task<ApiVideoPlayerWidgetResponseModel?> GetVideoPlayerWidgetAsync(string videoId)
+        {
+            // アカウント情報を取得し、存在しない場合は例外をスロー
+            var account = await _accountAccess.GetAccountAsync(_apiResourceConfigurations.ViAccountName) ?? throw new ArgumentNullException(paramName: ParamName);
+
+            // アカウント情報のチェック
+            _accountRepository.CheckAccount(account);
+
+            // アカウントのロケーションとIDを取得
+            string? location = account.location;
+            string? accountId = account.properties?.id;
+
+            // アクセストークンを取得
+            string accessToken = await _authenticationTokenizer.GetAccessToken();
+
+            // Video Player Widget の情報を取得
+            return await GetVideoPlayerWidgetAsync(location!, accountId!, videoId, accessToken);
+        }
+
+        /// <summary>
+        /// Video Player Widget の情報を取得します。
+        /// </summary>
+        /// <param name="location">API呼び出し先のリージョン（例：trial）</param>
+        /// <param name="accountId">Video Indexer アカウントの GUID</param>
+        /// <param name="videoId">対象のビデオID</param>
+        /// <param name="accessToken">（任意）アクセストークン。プライベートビデオなどに必要</param>
+        /// <returns>Player Widget URLを格納した <see cref="ApiVideoPlayerWidgetResponseModel"/>。失敗時は null</returns>
+        public async Task<ApiVideoPlayerWidgetResponseModel?> GetVideoPlayerWidgetAsync(string location, string accountId, string videoId, string? accessToken = null)
+        {
+            return await _widgetsApiAccess.GetVideoPlayerWidgetAsync(location, accountId, videoId, accessToken);
         }
     }
 }

--- a/VideoIndexerAccessCore/VideoIndexerClient/ApiAccess/IWidgetsApiAccess.cs
+++ b/VideoIndexerAccessCore/VideoIndexerClient/ApiAccess/IWidgetsApiAccess.cs
@@ -17,6 +17,19 @@ public interface IWidgetsApiAccess
     Task<ApiVideoInsightsWidgetResponseModel?> GetVideoInsightsWidgetAsync(string location, string accountId, string videoId, string? widgetType = null, bool? allowEdit = null, string? accessToken = null);
 
     /// <summary>
+    /// Insights Widget のURLを取得します。
+    /// Video Indexer API から Insights Widget のリダイレクトURLを取得し返却します。
+    /// </summary>
+    /// <param name="location">API呼び出し先のリージョン（例：trial）</param>
+    /// <param name="accountId">Video Indexer アカウントの GUID</param>
+    /// <param name="videoId">インサイトを取得する対象のビデオID</param>
+    /// <param name="widgetType">（任意）表示するウィジェットの種類（People / Sentiments / Keywords / Search）</param>
+    /// <param name="allowEdit">（任意）ウィジェットが編集可能かどうか</param>
+    /// <param name="accessToken">（任意）アクセストークン。編集やプライベートビデオの場合に必要</param>
+    /// <returns>リダイレクトされた Insights Widget のURL。失敗時は null</returns>
+    Task<string?> GetVideoInsightsWidgetUrl(string location, string accountId, string videoId, string? widgetType, bool? allowEdit, string? accessToken);
+
+    /// <summary>
     /// Insights Widget API にアクセスし JSON レスポンスを取得します。
     /// </summary>
     /// <param name="location">API呼び出し先のリージョン（例：trial）</param>
@@ -34,6 +47,18 @@ public interface IWidgetsApiAccess
     /// <param name="json">APIから取得したJSON文字列</param>
     /// <returns>デシリアライズされた <see cref="ApiVideoInsightsWidgetResponseModel"/> オブジェクト。失敗時は null</returns>
     ApiVideoInsightsWidgetResponseModel? ParseVideoInsightsJson(string json);
+
+    /// <summary>
+    /// Video Player Widget のリダイレクトURLを取得します。
+    /// Video Indexer API から Player Widget のリダイレクトURLを取得し返却します。
+    /// </summary>
+    /// <param name="location">API呼び出し先のリージョン（例：trial）</param>
+    /// <param name="accountId">Video Indexer アカウントの GUID</param>
+    /// <param name="videoId">対象のビデオID</param>
+    /// <param name="accessToken">（任意）アクセストークン。プライベートビデオなどに必要</param>
+    /// <returns>リダイレクトされた Player Widget のURL。失敗時は null</returns>
+    Task<string?> GetVideoPlayerWidgetUrl(string location, string accountId, string videoId, string? accessToken = null);
+
 
     /// <summary>
     /// 外部公開用メソッド。Video Player Widget の情報を取得します。

--- a/VideoIndexerAccessCore/VideoIndexerClient/ApiAccess/WidgetsApiAccess.cs
+++ b/VideoIndexerAccessCore/VideoIndexerClient/ApiAccess/WidgetsApiAccess.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using System.Net;
 using System.Text.Json;
 using VideoIndexerAccessCore.VideoIndexerClient.ApiModel;
 using VideoIndexerAccessCore.VideoIndexerClient.Configuration;
@@ -41,6 +42,46 @@ namespace VideoIndexerAccessCore.VideoIndexerClient.ApiAccess
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Unexpected error occurred while retrieving video insights.");
+                return null;
+            }
+        }
+
+
+        /// <summary>
+        /// Insights Widget のURLを取得します。
+        /// Video Indexer API から Insights Widget のリダイレクトURLを取得し返却します。
+        /// </summary>
+        /// <param name="location">API呼び出し先のリージョン（例：trial）</param>
+        /// <param name="accountId">Video Indexer アカウントの GUID</param>
+        /// <param name="videoId">インサイトを取得する対象のビデオID</param>
+        /// <param name="widgetType">（任意）表示するウィジェットの種類（People / Sentiments / Keywords / Search）</param>
+        /// <param name="allowEdit">（任意）ウィジェットが編集可能かどうか</param>
+        /// <param name="accessToken">（任意）アクセストークン。編集やプライベートビデオの場合に必要</param>
+        /// <returns>リダイレクトされた Insights Widget のURL。失敗時は null</returns>
+        public async Task<string?> GetVideoInsightsWidgetUrl(string location, string accountId, string videoId, string? widgetType, bool? allowEdit, string? accessToken)
+        {
+            var url = $"{_apiResourceConfigurations.ApiEndpoint}/{location}/Accounts/{accountId}/Videos/{videoId}/InsightsWidget";
+
+            var query = System.Web.HttpUtility.ParseQueryString(string.Empty);
+            if (!string.IsNullOrEmpty(widgetType)) query["widgetType"] = widgetType;
+            if (allowEdit.HasValue) query["allowEdit"] = allowEdit.Value.ToString().ToLower();
+            if (!string.IsNullOrEmpty(accessToken)) query["accessToken"] = accessToken;
+            var finalUrl = $"{url}?{query}";
+
+            HttpClient httpClient = _durableHttpClient?.HttpClient ?? new HttpClient();
+            var response = await httpClient.GetAsync(finalUrl) ?? throw new HttpRequestException("The response was null.");
+
+            if (response.StatusCode == HttpStatusCode.Moved || response.StatusCode == HttpStatusCode.Redirect || response.StatusCode == HttpStatusCode.MovedPermanently)
+            {
+                string widgetUrl = response.Headers.Location?.ToString() ?? throw new HttpRequestException("Redirect Location header is missing.");
+                _logger.LogInformation("Widget URL: {WidgetUrl}", widgetUrl);
+                return widgetUrl;
+            }
+            else
+            {
+                _logger.LogWarning("Status code: {StatusCode}", response.StatusCode);
+                string error = await response.Content.ReadAsStringAsync();
+                _logger.LogWarning("Error: {Error}", error);
                 return null;
             }
         }
@@ -102,6 +143,44 @@ namespace VideoIndexerAccessCore.VideoIndexerClient.ApiAccess
         // Get Video Player Widget
 
         /// <summary>
+        /// Video Player Widget のリダイレクトURLを取得します。
+        /// Video Indexer API から Player Widget のリダイレクトURLを取得し返却します。
+        /// </summary>
+        /// <param name="location">API呼び出し先のリージョン（例：trial）</param>
+        /// <param name="accountId">Video Indexer アカウントの GUID</param>
+        /// <param name="videoId">対象のビデオID</param>
+        /// <param name="accessToken">（任意）アクセストークン。プライベートビデオなどに必要</param>
+        /// <returns>リダイレクトされた Player Widget のURL。失敗時は null</returns>
+        public async Task<string?> GetVideoPlayerWidgetUrl(string location, string accountId, string videoId, string? accessToken = null)
+        {
+            try
+            {
+                var url = $"{_apiResourceConfigurations.ApiEndpoint}/{location}/Accounts/{accountId}/Videos/{videoId}/PlayerWidget";
+                var query = System.Web.HttpUtility.ParseQueryString(string.Empty);
+                if (!string.IsNullOrEmpty(accessToken)) query["accessToken"] = accessToken;
+                var finalUrl = $"{url}?{query}";
+                HttpClient httpClient = _durableHttpClient?.HttpClient ?? new HttpClient();
+                var response = await httpClient.GetAsync(finalUrl) ?? throw new HttpRequestException("The response was null.");
+                if (response.StatusCode == HttpStatusCode.Moved || response.StatusCode == HttpStatusCode.Redirect || response.StatusCode == HttpStatusCode.MovedPermanently)
+                {
+                    return response.Headers.Location?.ToString() ?? throw new HttpRequestException("Redirect Location header is missing.");
+                }
+                else
+                {
+                    _logger.LogWarning("Status code: {StatusCode}", response.StatusCode);
+                    string error = await response.Content.ReadAsStringAsync();
+                    _logger.LogWarning("Error: {Error}", error);
+                    return null;
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "HTTP request error while calling Video Player Widget API.");
+                return null;
+            }
+        }
+
+        /// <summary>
         /// 外部公開用メソッド。Video Player Widget の情報を取得します。
         /// </summary>
         /// <param name="location">API呼び出し先のリージョン（例：trial）</param>
@@ -109,11 +188,7 @@ namespace VideoIndexerAccessCore.VideoIndexerClient.ApiAccess
         /// <param name="videoId">対象のビデオID</param>
         /// <param name="accessToken">（任意）アクセストークン。プライベートビデオなどに必要</param>
         /// <returns>Player Widget URLを格納した <see cref="ApiVideoPlayerWidgetResponseModel"/>。失敗時は null</returns>
-        public async Task<ApiVideoPlayerWidgetResponseModel?> GetVideoPlayerWidgetAsync(
-            string location,
-            string accountId,
-            string videoId,
-            string? accessToken = null)
+        public async Task<ApiVideoPlayerWidgetResponseModel?> GetVideoPlayerWidgetAsync(string location, string accountId, string videoId, string? accessToken = null)
         {
             try
             {


### PR DESCRIPTION
`WidgetRepository` に `IVideoInsightsWidgetResponseMapper` を追加し、ウィジェットのURLや情報を取得するメソッドを実装しました。 `IWidgetsApiAccess` にも新たにウィジェットのURLを取得するメソッドを追加し、`WidgetsApiAccess` での実装を行いました。 さらに、APIレスポンスをマッピングするためのインターフェースと実装を追加し、ウィジェット情報を格納するモデルも定義しました。 これにより、APIとのインタラクションがより効率的になりました。