### PR TITLE
ビデオプレイヤーウィジェットのレスポンス処理を追加

### DIFF
--- a/VideoIndexerAccess/Repositories/DataModel/VideoPlayerWidgetResponseModel.cs
+++ b/VideoIndexerAccess/Repositories/DataModel/VideoPlayerWidgetResponseModel.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VideoIndexerAccess.Repositories.DataModel
+{
+    public class VideoPlayerWidgetResponseModel
+    {
+        /// <summary>
+        /// プレイヤーウィジェットの表示URL（リダイレクト先）
+        /// </summary>
+        public string? PlayerWidgetUrl { get; set; }
+
+        /// <summary>
+        /// エラーの種類（発生した場合）
+        /// </summary>
+        public string? ErrorType { get; set; }
+
+        /// <summary>
+        /// エラーメッセージ（発生した場合）
+        /// </summary>
+        public string? Message { get; set; }
+    }
+}

--- a/VideoIndexerAccess/Repositories/DataModelMapper/IVideoPlayerWidgetResponseMapper.cs
+++ b/VideoIndexerAccess/Repositories/DataModelMapper/IVideoPlayerWidgetResponseMapper.cs
@@ -1,0 +1,10 @@
+﻿using VideoIndexerAccess.Repositories.DataModel;
+using VideoIndexerAccessCore.VideoIndexerClient.ApiModel;
+
+namespace VideoIndexerAccess.Repositories.DataModelMapper;
+
+public interface IVideoPlayerWidgetResponseMapper
+{
+    VideoPlayerWidgetResponseModel MapFrom(ApiVideoPlayerWidgetResponseModel model);
+    ApiVideoPlayerWidgetResponseModel MapToApiVideoPlayerWidgetResponseModel(VideoPlayerWidgetResponseModel model);
+}

--- a/VideoIndexerAccess/Repositories/DataModelMapper/VideoPlayerWidgetResponseMapper.cs
+++ b/VideoIndexerAccess/Repositories/DataModelMapper/VideoPlayerWidgetResponseMapper.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VideoIndexerAccess.Repositories.DataModel;
+using VideoIndexerAccessCore.VideoIndexerClient.ApiModel;
+
+namespace VideoIndexerAccess.Repositories.DataModelMapper
+{
+    public class VideoPlayerWidgetResponseMapper : IVideoPlayerWidgetResponseMapper
+    {
+        public VideoPlayerWidgetResponseModel MapFrom(ApiVideoPlayerWidgetResponseModel model)
+        {
+            if (model == null) throw new ArgumentNullException(nameof(model));
+            return new VideoPlayerWidgetResponseModel
+            {
+                PlayerWidgetUrl = model.playerWidgetUrl,
+                ErrorType = model.errorType,
+                Message = model.message
+            };
+        }
+
+        public ApiVideoPlayerWidgetResponseModel MapToApiVideoPlayerWidgetResponseModel(VideoPlayerWidgetResponseModel model)
+        {
+            if (model == null) throw new ArgumentNullException(nameof(model));
+            return new ApiVideoPlayerWidgetResponseModel
+            {
+                playerWidgetUrl = model.PlayerWidgetUrl,
+                errorType = model.ErrorType,
+                message = model.Message
+            };
+        }
+    }
+}

--- a/VideoIndexerAccess/Repositories/VideoItemRepository/WidgetRepository.cs
+++ b/VideoIndexerAccess/Repositories/VideoItemRepository/WidgetRepository.cs
@@ -36,8 +36,9 @@ namespace VideoIndexerAccess.Repositories.VideoItemRepository
 
         // マッパーインターフェース
         private readonly IVideoInsightsWidgetResponseMapper _insightsWidgetResponseMapper;
+        private readonly IVideoPlayerWidgetResponseMapper _videoPlayerWidgetResponseMapper;
 
-        public WidgetRepository(ILogger<WidgetRepository> logger, IAuthenticationTokenizer authenticationTokenizer, IAccounApitAccess accountAccess, IAccountRepository accountRepository, IApiResourceConfigurations apiResourceConfigurations, IWidgetsApiAccess widgetsApiAccess, IVideoInsightsWidgetResponseMapper insightsWidgetResponseMapper)
+        public WidgetRepository(ILogger<WidgetRepository> logger, IAuthenticationTokenizer authenticationTokenizer, IAccounApitAccess accountAccess, IAccountRepository accountRepository, IApiResourceConfigurations apiResourceConfigurations, IWidgetsApiAccess widgetsApiAccess, IVideoInsightsWidgetResponseMapper insightsWidgetResponseMapper, IVideoPlayerWidgetResponseMapper videoPlayerWidgetResponseMapper)
         {
             _logger = logger;
             _authenticationTokenizer = authenticationTokenizer;
@@ -46,6 +47,7 @@ namespace VideoIndexerAccess.Repositories.VideoItemRepository
             _apiResourceConfigurations = apiResourceConfigurations;
             _widgetsApiAccess = widgetsApiAccess;
             _insightsWidgetResponseMapper = insightsWidgetResponseMapper;
+            _videoPlayerWidgetResponseMapper = videoPlayerWidgetResponseMapper;
         }
 
 
@@ -169,7 +171,7 @@ namespace VideoIndexerAccess.Repositories.VideoItemRepository
         /// </summary>
         /// <param name="videoId">対象のビデオID</param>
         /// <returns>Player Widget URLを格納した <see cref="ApiVideoPlayerWidgetResponseModel"/>。失敗時は null</returns>
-        public async Task<ApiVideoPlayerWidgetResponseModel?> GetVideoPlayerWidgetAsync(string videoId)
+        public async Task<VideoPlayerWidgetResponseModel?> GetVideoPlayerWidgetAsync(string videoId)
         {
             // アカウント情報を取得し、存在しない場合は例外をスロー
             var account = await _accountAccess.GetAccountAsync(_apiResourceConfigurations.ViAccountName) ?? throw new ArgumentNullException(paramName: ParamName);
@@ -196,9 +198,10 @@ namespace VideoIndexerAccess.Repositories.VideoItemRepository
         /// <param name="videoId">対象のビデオID</param>
         /// <param name="accessToken">（任意）アクセストークン。プライベートビデオなどに必要</param>
         /// <returns>Player Widget URLを格納した <see cref="ApiVideoPlayerWidgetResponseModel"/>。失敗時は null</returns>
-        public async Task<ApiVideoPlayerWidgetResponseModel?> GetVideoPlayerWidgetAsync(string location, string accountId, string videoId, string? accessToken = null)
+        public async Task<VideoPlayerWidgetResponseModel?> GetVideoPlayerWidgetAsync(string location, string accountId, string videoId, string? accessToken = null)
         {
-            return await _widgetsApiAccess.GetVideoPlayerWidgetAsync(location, accountId, videoId, accessToken);
+            ApiVideoPlayerWidgetResponseModel? responseModel = await _widgetsApiAccess.GetVideoPlayerWidgetAsync(location, accountId, videoId, accessToken);
+            return responseModel is null ? null : _videoPlayerWidgetResponseMapper.MapFrom(responseModel);
         }
     }
 }


### PR DESCRIPTION
`WidgetRepository` に新しいフィールドとマッピングロジックを追加し、`GetVideoPlayerWidgetAsync` メソッドの戻り値の型を変更しました。 新しいインターフェース `IVideoPlayerWidgetResponseMapper` を定義し、マッピングを実装する `VideoPlayerWidgetResponseMapper` クラスを追加しました。 さらに、ビデオプレイヤーウィジェットのレスポンスを表す `VideoPlayerWidgetResponseModel` クラスを新たに作成しました。