### PR TITLE
依存関係の追加と削除

### DIFF
--- a/VideoIndexerAccessCoreExtension/Service/VideoIndexerApiService.cs
+++ b/VideoIndexerAccessCoreExtension/Service/VideoIndexerApiService.cs
@@ -30,6 +30,7 @@ namespace VideoIndexerAccessCoreExtension.Service
             services.TryAddTransient<ISecureLogMessageBuilder, SecureLogMessageBuilder>();
             services.TryAddTransient<IAccounApitAccess, AccountApiAccess>();
             services.TryAddTransient<IBrandsApiAccess, BrandsApiAccess>();
+            services.TryAddTransient<IClassicLanguageCustomizationApiAccess, ClassicLanguageCustomizationApiAccess>();
             services.TryAddTransient<IProjectMigrationApiAccess, ProjectMigrationApiAccess>();
             services.TryAddTransient<IVideoArtifactApiAccess, VideoArtifactApiAccess>();
             services.TryAddTransient<IVideoDownloadApiAccess, VideoDownloadApiAccess>();

--- a/VideoIndexerAccessExtension/Service/VideoIndexerAccessExtension.cs
+++ b/VideoIndexerAccessExtension/Service/VideoIndexerAccessExtension.cs
@@ -34,16 +34,31 @@ public static class VideoIndexerAccessExtension
 
     public static IServiceCollection AddVideoIndexerDataModelMapper(this IServiceCollection services)
     {
+        services.TryAddTransient<IAccountMigrationStatusMapper, AccountMigrationStatusMapper>();
+        services.TryAddTransient<IAccountSlimMapper, AccountSlimMapper>();
         services.TryAddTransient<IAppearanceMapper, AppearanceMapper>();
         services.TryAddTransient<IAudioEffectsMapper, AudioEffectsMapper>();
+        services.TryAddTransient<IBlockMapper, BlockMapper>();
         services.TryAddTransient<IBrandMapper, BrandMapper>();
+        services.TryAddTransient<IBrandModelMapper, BrandModelMapper>();
+        services.TryAddTransient<IBrandModelSettingsMapper, BrandModelSettingsMapper>();
+        services.TryAddTransient<IBrandsMapper, BrandsMapper>();
+        services.TryAddTransient<ICustomLanguageMapper, CustomLanguageMapper>();
+        services.TryAddTransient<ICustomLanguageModelTrainingDataFileMapper, ICustomLanguageModelTrainingDataFileMapper>();
+        services.TryAddTransient<ICustomLanguageRequestMapper, CustomLanguageRequestMapper>();
+        services.TryAddTransient<IDeleteVideoResultMapper, DeleteVideoResultMapper>();
         services.TryAddTransient<IDurationMapper, DurationMapper>();
         services.TryAddTransient<IEmotionsMapper, EmotionsMapper>();
+        services.TryAddTransient<IErrorResponseMapper, ErrorResponseMapper>();
+        services.TryAddTransient<IFaceFilterMapper, FaceFilterMapper>();
         services.TryAddTransient<IFaceMapper, FaceMapper>();
+        services.TryAddTransient<IFaceRedactionMapper, FaceRedactionMapper>();
         services.TryAddTransient<IFramePatternsMapper, FramePatternsMapper>();
         services.TryAddTransient<IInsightsMapper, InsightsMapper>();
         services.TryAddTransient<IInstanceMapper, InstanceMapper>();
         services.TryAddTransient<IItemVideoMapper, ItemVideoMapper>();
+        services.TryAddTransient<IJobStatusResponseMapper, JobStatusResponseMapper>();
+        services.TryAddTransient<IKeyFrameMapper, KeyFrameMapper>();
         services.TryAddTransient<IKeyWordMapper, KeyWordMapper>();
         services.TryAddTransient<ILabelMapper, LabelMapper>();
         services.TryAddTransient<INamedLocationMapper, NamedLocationMapper>();
@@ -83,8 +98,6 @@ public static class VideoIndexerAccessExtension
         services.TryAddTransient<IVideoArtifactApiAccess, VideoArtifactApiAccess>();
         services.TryAddTransient<IVideoDownloadApiAccess, VideoDownloadApiAccess>();
         services.TryAddTransient<IVideoIndexApiAccess, VideoIndexApiAccess>();
-        services.TryAddTransient<IClassicLanguageCustomizationApiAccess, ClassicLanguageCustomizationApiAccess>();
-        services.TryAddTransient<IAccountMigrationStatusMapper, AccountMigrationStatusMapper>();
 
         return services;
     }


### PR DESCRIPTION
`VideoIndexerApiService.cs` に `IClassicLanguageCustomizationApiAccess` を追加しました。 `VideoIndexerAccessExtension.cs` では、複数のマッパーが追加され、特に `IAccountMigrationStatusMapper`、`IAccountSlimMapper`、`IBlockMapper` などが含まれています。 また、`IClassicLanguageCustomizationApiAccess` と `IAccountMigrationStatusMapper` の依存関係が削除されました。