### PR TITLE
名前空間の整理とサービスの追加

### DIFF
--- a/VideoIndexerAccess/Repositories/VideoItemRepository/VideosRepository.cs
+++ b/VideoIndexerAccess/Repositories/VideoItemRepository/VideosRepository.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection.Metadata.Ecma335;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using VideoIndexerAccess.Repositories.AuthorizAccess;
 using VideoIndexerAccess.Repositories.DataModel;
 using VideoIndexerAccess.Repositories.DataModelMapper;

--- a/VideoIndexerAccessCore/VideoIndexerClient/Authorization/AccountTokenProviderDynamic.cs
+++ b/VideoIndexerAccessCore/VideoIndexerClient/Authorization/AccountTokenProviderDynamic.cs
@@ -1,8 +1,8 @@
-﻿using System.Net.Http.Headers;
-using System.Text.Json;
-using Azure.Core;
+﻿using Azure.Core;
 using Azure.Identity;
 using Microsoft.Extensions.Logging;
+using System.Net.Http.Headers;
+using System.Text.Json;
 using VideoIndexerAccessCore.VideoIndexerClient.Configuration;
 using VideoIndexerAccessCore.VideoIndexerClient.HttpAccess;
 

--- a/VideoIndexerAccessCoreExtension/Service/VideoIndexerApiService.cs
+++ b/VideoIndexerAccessCoreExtension/Service/VideoIndexerApiService.cs
@@ -28,22 +28,17 @@ namespace VideoIndexerAccessCoreExtension.Service
         public static IServiceCollection AddVideoIndexerApi(this IServiceCollection services)
         {
             services.TryAddTransient<ISecureLogMessageBuilder, SecureLogMessageBuilder>();
+
             services.TryAddTransient<IAccounApitAccess, AccountApiAccess>();
+            services.TryAddTransient<IAccountMigrationStatusApiAccess, AccountMigrationStatusApiAccess>();
             services.TryAddTransient<IBrandsApiAccess, BrandsApiAccess>();
             services.TryAddTransient<IClassicLanguageCustomizationApiAccess, ClassicLanguageCustomizationApiAccess>();
-            services.TryAddTransient<IProjectMigrationApiAccess, ProjectMigrationApiAccess>();
-            services.TryAddTransient<IVideoArtifactApiAccess, VideoArtifactApiAccess>();
-            services.TryAddTransient<IVideoDownloadApiAccess, VideoDownloadApiAccess>();
-            services.TryAddTransient<IVideoIndexApiAccess, VideoIndexApiAccess>();
-            services.TryAddTransient<IVideoItemParser, VideoItemParser>();
-            services.TryAddTransient<IVideoListParser, VideoListParser>();
-            services.TryAddTransient<IVideoListApiAccess, VideoListAccessApiAccess>();
-            services.TryAddTransient<IVideoMigrationApiAccess, VideoMigrationApiAccess>();
             services.TryAddTransient<ICustomLogosApiAccess, CustomLogosApiAccess>();
             services.TryAddTransient<IIndexingApiAccess, IndexingApiAccess>();
             services.TryAddTransient<IJobsApiAccess, JobsApiAccess>();
             services.TryAddTransient<ILanguagesApiAccess, LanguagesApiAccess>();
             services.TryAddTransient<IPersonModelsApiAccess, PersonModelsApiAccess>();
+            services.TryAddTransient<IProjectMigrationApiAccess, ProjectMigrationApiAccess>();
             services.TryAddTransient<IProjectsApiAccess, ProjectsApiAccess>();
             services.TryAddTransient<IPromptContentApiAccess, PromptContentApiAccess>();
             services.TryAddTransient<IRedactionApiAccess, RedactionApiAccess>();
@@ -51,8 +46,16 @@ namespace VideoIndexerAccessCoreExtension.Service
             services.TryAddTransient<ITextualSummarizationApiAccess, TextualSummarizationApiAccess>();
             services.TryAddTransient<ITrialAccountAccessTokensApiAccess, TrialAccountAccessTokensApiAccess>();
             services.TryAddTransient<ITrialAccountsApiAccess, TrialAccountsApiAccess>();
+            services.TryAddTransient<IVideoArtifactApiAccess, VideoArtifactApiAccess>();
+            services.TryAddTransient<IVideoDownloadApiAccess, VideoDownloadApiAccess>();
+            services.TryAddTransient<IVideoIndexApiAccess, VideoIndexApiAccess>();
+            services.TryAddTransient<IVideoListApiAccess, VideoListAccessApiAccess>();
+            services.TryAddTransient<IVideoMigrationApiAccess, VideoMigrationApiAccess>();
             services.TryAddTransient<IVideosApiAccess, VideosApiAccess>();
             services.TryAddTransient<IWidgetsApiAccess, WidgetsApiAccess>();
+            
+            services.TryAddTransient<IVideoListParser, VideoListParser>();
+            services.TryAddTransient<IVideoItemParser, VideoItemParser>();
             
             return services;
         }


### PR DESCRIPTION
`VideosRepository.cs` と `AccountTokenProviderDynamic.cs` で `using` ステートメントを整理し、関連する名前空間を追加しました。 `VideoIndexerApiService.cs` の `AddVideoIndexerApi` メソッド内で、いくつかのサービスを追加し、特定のサービスを削除しました。これにより、依存関係の管理が改善されました。