### PR TITLE
名前空間の追加

### DIFF
--- a/VideoIndexerAccess/Repositories/VideoItemRepository/AccountRepository.cs
+++ b/VideoIndexerAccess/Repositories/VideoItemRepository/AccountRepository.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using VideoIndexerAccessCore.VideoIndexerClient.ApiModel;
 
 namespace VideoIndexerAccess.Repositories.VideoItemRepository


### PR DESCRIPTION
`AccountRepository` クラスに `VideoIndexerAccessCore.VideoIndexerClient.ApiModel` 名前空間を追加しました。これにより、関連機能を利用できるようになります。