### PR TITLE
プロジェクトファイルの更新と依存関係の変更

### DIFF
--- a/VideoIndexerAccess/VideoIndexerAccess.csproj
+++ b/VideoIndexerAccess/VideoIndexerAccess.csproj
@@ -20,14 +20,11 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.AutoActivation" Version="9.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\VideoIndexerAccessCoreExtension\VideoIndexerAccessCoreExtension.csproj" />
+    <PackageReference Include="VideoIndexerAccessCore" Version="1.0.1-alpha05.5" />
   </ItemGroup>
 	
   <PropertyGroup>
-	<Version>1.0.1-alpha05.4</Version>
+	<Version>1.0.1-alpha05.5</Version>
 	<PackageReleaseNotes>Azure AI Video アクセス SDK </PackageReleaseNotes>
 	<PackageIcon>AirTurn02-240x240.jpg</PackageIcon>
 	<SignAssembly>False</SignAssembly>
@@ -36,10 +33,12 @@
 	<Company>LLC Beans</Company><!-- 新しいバージョン番号 -->
 	<!-- NuGet メタデータ -->
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<PackageProjectUrl>https://fairuse@dev.azure.com/fairuse/AzureVideoIndexer/_git/videoIndexerPocMark</PackageProjectUrl>
-	<RepositoryUrl>https://fairuse@dev.azure.com/fairuse/AzureVideoIndexer/_git/videoIndexerPocMark</RepositoryUrl>
+	<PackageProjectUrl>https://github.com/ueshiman/VideoIndexerSDK/tree/main/VideoIndexerAccess</PackageProjectUrl>
+	<RepositoryUrl>https://github.com/ueshiman/VideoIndexerSDK/tree/main/VideoIndexerAccess</RepositoryUrl>
 	<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 	<Copyright>Copyright (c) 2025 Ueshiman</Copyright>
+	<RepositoryType>git</RepositoryType>
+	<Authors>Ueshiman</Authors>
 	<!--<PackageLicenseFile>LICENSE</PackageLicenseFile>-->
   </PropertyGroup>
 

--- a/VideoIndexerAccessCore/VideoIndexerAccessCore.csproj
+++ b/VideoIndexerAccessCore/VideoIndexerAccessCore.csproj
@@ -32,14 +32,17 @@
   </ItemGroup>
 
   <PropertyGroup>
-	<Version>1.0.1-alpha05.2</Version>
+	<Version>1.0.1-alpha05.5</Version>
 	<IncludeSymbols>True</IncludeSymbols><!-- 新しいバージョン番号 -->
 	  <!-- NuGet メタデータ -->
 	  <PackageLicenseExpression>MIT</PackageLicenseExpression>
-	  <PackageProjectUrl>https://fairuse@dev.azure.com/fairuse/AzureVideoIndexer/_git/videoIndexerPocMark</PackageProjectUrl>
-	  <RepositoryUrl>https://fairuse@dev.azure.com/fairuse/AzureVideoIndexer/_git/videoIndexerPocMark</RepositoryUrl>
+	  <PackageProjectUrl>https://github.com/ueshiman/VideoIndexerSDK/tree/main/VideoIndexerAccessCore</PackageProjectUrl>
+	  <RepositoryUrl>https://github.com/ueshiman/VideoIndexerSDK/tree/main/VideoIndexerAccessCore</RepositoryUrl>
 	  <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 	  <Copyright>Copyright (c) 2025 Ueshiman</Copyright>
+	  <RepositoryType>git</RepositoryType>
+	  <Authors>Ueshiman</Authors>
+	  <Company>LLP Honjo open source</Company>
 	  <!--<PackageLicenseFile>LICENSE</PackageLicenseFile>-->
   </PropertyGroup>
 

--- a/VideoIndexerAccessCoreExtension/VideoIndexerAccessCoreExtension.csproj
+++ b/VideoIndexerAccessCoreExtension/VideoIndexerAccessCoreExtension.csproj
@@ -22,21 +22,20 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
-    <PackageReference Include="VideoIndexerAccessCore" Version="1.0.1-alpha05.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\VideoIndexerAccessCore\VideoIndexerAccessCore.csproj" />
+    <PackageReference Include="VideoIndexerAccessCore" Version="1.0.1-alpha05.5" />
   </ItemGroup>
 
   <PropertyGroup>
-	<Version>1.0.1-alpha05.2</Version><!-- 新しいバージョン番号 -->
+	<Version>1.0.1-alpha05.5</Version><!-- 新しいバージョン番号 -->
 	<!-- NuGet メタデータ -->
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<PackageProjectUrl>https://fairuse@dev.azure.com/fairuse/AzureVideoIndexer/_git/videoIndexerPocMark</PackageProjectUrl>
-	<RepositoryUrl>https://fairuse@dev.azure.com/fairuse/AzureVideoIndexer/_git/videoIndexerPocMark</RepositoryUrl>
+	<PackageProjectUrl>https://github.com/ueshiman/VideoIndexerSDK/tree/main/VideoIndexerAccessCoreExtension</PackageProjectUrl>
+	<RepositoryUrl>https://github.com/ueshiman/VideoIndexerSDK/tree/main/VideoIndexerAccessCoreExtension</RepositoryUrl>
 	<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 	<Copyright>Copyright (c) 2025 Ueshiman</Copyright>
+	<Authors>Ueshiman</Authors>
+	<Company>LLP Hojo open source</Company>
+	<RepositoryType>git</RepositoryType>
 	<!--<PackageLicenseFile>LICENSE</PackageLicenseFile>-->
   </PropertyGroup>
 

--- a/VideoIndexerAccessExtension/VideoIndexerAccessExtension.csproj
+++ b/VideoIndexerAccessExtension/VideoIndexerAccessExtension.csproj
@@ -25,23 +25,23 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\VideoIndexerAccessCore\VideoIndexerAccessCore.csproj" />
-    <ProjectReference Include="..\VideoIndexerAccess\VideoIndexerAccess.csproj" />
+    <PackageReference Include="VideoIndexerAccess" Version="1.0.1-alpha05.5" />
+    <PackageReference Include="VideoIndexerAccessCoreExtension" Version="1.0.1-alpha05.5" />
   </ItemGroup>
 
 
   <PropertyGroup>
-	<Version>1.0.1-alpha05.4</Version>
+	<Version>1.0.1-alpha05.5</Version>
 	<!-- 新しいバージョン番号 -->
 	<!-- NuGet メタデータ -->
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<PackageProjectUrl>https://fairuse@dev.azure.com/fairuse/AzureVideoIndexer/_git/videoIndexerPocMark</PackageProjectUrl>
-	<RepositoryUrl>https://fairuse@dev.azure.com/fairuse/AzureVideoIndexer/_git/videoIndexerPocMark</RepositoryUrl>
+	<PackageProjectUrl>https://github.com/ueshiman/VideoIndexerSDK/tree/main/VideoIndexerAccessExtension</PackageProjectUrl>
+	<RepositoryUrl>https://github.com/ueshiman/VideoIndexerSDK/tree/main/VideoIndexerAccessExtension</RepositoryUrl>
 	<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 	<Copyright>Copyright (c) 2025 Ueshiman</Copyright>
+	<Authors>Ueshiman</Authors>
+	<Company>LLC Beans</Company>
+	<RepositoryType>git</RepositoryType>
 	<!--<PackageLicenseFile>LICENSE</PackageLicenseFile>-->
   </PropertyGroup>
 


### PR DESCRIPTION
プロジェクト `VideoIndexerAccess`、`VideoIndexerAccessCore`、`VideoIndexerAccessCoreExtension`、および `VideoIndexerAccessExtension` のバージョンを `1.0.1-alpha05.2` から `1.0.1-alpha05.5` に更新しました。依存関係を `ProjectReference` から `PackageReference` に変更し、リポジトリURLをAzure DevOpsからGitHubに移行しました。著作権情報と著者情報も追加されました。